### PR TITLE
hotfix: correct vercel deployment argument to use vercel-args

### DIFF
--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -37,7 +37,7 @@ jobs:
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
           working-directory: ./
-          production: true
+          vercel-args: '--prod'
 
       - name: Deployment summary
         if: success()


### PR DESCRIPTION
This pull request makes a small update to the Vercel deployment workflow configuration. The change improves how production deployments are triggered by replacing the `production: true` flag with the recommended `vercel-args: '--prod'` option.

* Updated the Vercel deployment step in `.github/workflows/deploy-vercel.yml` to use `vercel-args: '--prod'` instead of `production: true`, ensuring production deployments follow current best practices.
[Copilot is generating a summary...]